### PR TITLE
MultiTarget tests, Make code compatible with net48/47 projects with r…

### DIFF
--- a/source/Sylvan.Data.Excel.Tests/Sylvan.Data.Excel.Tests.csproj
+++ b/source/Sylvan.Data.Excel.Tests/Sylvan.Data.Excel.Tests.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Sylvan.Data" Version="0.1.0-B0021" />
     <PackageReference Include="Sylvan.Data.Csv" Version="0.10.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+	<PackageReference Include="xunit" Version="2.4.0" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sylvan.Data.Excel.Tests/Sylvan.Data.Excel.Tests.csproj
+++ b/source/Sylvan.Data.Excel.Tests/Sylvan.Data.Excel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <RootNamespace>Sylvan.Data.Excel</RootNamespace>
     <IsPackable>false</IsPackable>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
@@ -11,8 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Sylvan.Data" Version="0.1.0-B0021" />
     <PackageReference Include="Sylvan.Data.Csv" Version="0.10.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/source/Sylvan.Data.Excel/ExcelColumn.cs
+++ b/source/Sylvan.Data.Excel/ExcelColumn.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿#nullable enable
+using System.Data.Common;
 
 namespace Sylvan.Data.Excel;
 

--- a/source/Sylvan.Data.Excel/ExcelDataReader.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/source/Sylvan.Data.Excel/ExcelFormat.cs
+++ b/source/Sylvan.Data.Excel/ExcelFormat.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 
 namespace Sylvan.Data.Excel;

--- a/source/Sylvan.Data.Excel/ExcelSchema.cs
+++ b/source/Sylvan.Data.Excel/ExcelSchema.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;

--- a/source/Sylvan.Data.Excel/IExcelSchemaProvider.cs
+++ b/source/Sylvan.Data.Excel/IExcelSchemaProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿#nullable enable
+using System.Data.Common;
 
 namespace Sylvan.Data.Excel;
 

--- a/source/Sylvan.Data.Excel/IsoDate.cs
+++ b/source/Sylvan.Data.Excel/IsoDate.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
 using System.Text;
 using ReadonlyCharSpan = System.String;
 using CharSpan = System.Text.StringBuilder;
@@ -560,7 +560,7 @@ static partial class IsoDate
     static string GetString(ReadonlyCharSpan buffer)
 	{
 
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
 		return buffer;
 #else
         return new string(buffer);
@@ -572,7 +572,7 @@ static partial class IsoDate
 
 	public static string ToStringIso(DateTime value)
 	{
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
         CharSpan buffer = RunTimeCompatability.AllocateCharSpan(MaxDateLength);
 #else
         CharSpan buffer = stackalloc char[MaxDateLength];
@@ -596,7 +596,7 @@ static partial class IsoDate
 
 	public static string ToDateStringIso(DateTime value)
 	{
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
         CharSpan buffer = RunTimeCompatability.AllocateCharSpan(10);
 #else
         CharSpan buffer = stackalloc char[10];
@@ -646,7 +646,7 @@ static partial class IsoDate
 
 	public static string ToStringIso(DateTimeOffset value)
 	{
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
         CharSpan buffer = RunTimeCompatability.AllocateCharSpan(MaxDateLength);
 #else
         CharSpan buffer = stackalloc char[MaxDateLength];
@@ -848,7 +848,7 @@ static partial class IsoDate
 		buffer[startingIndex] = (char)('0' + value);
 	}
 
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static void WriteTwoDigits(uint value, ReadonlyCharSpan buffer, int startingIndex = 0)
     {
@@ -867,7 +867,7 @@ static partial class IsoDate
 		buffer[startingIndex] = (char)('0' + value);
 	}
 
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static void WriteDigits(uint value, ReadonlyCharSpan buffer)
     {

--- a/source/Sylvan.Data.Excel/Packaging/Ole2Package.cs
+++ b/source/Sylvan.Data.Excel/Packaging/Ole2Package.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/source/Sylvan.Data.Excel/RunTimeCompatability.cs
+++ b/source/Sylvan.Data.Excel/RunTimeCompatability.cs
@@ -1,0 +1,51 @@
+﻿#if NETSTANDARD2_0
+
+using ReadonlyCharSpan = System.String;
+using CharSpan = System.Text.StringBuilder;
+
+namespace Sylvan;
+
+internal static class RunTimeCompatability
+{
+    public static ReadonlyCharSpan AsSpan(this char[] value)
+    {
+        return new ReadonlyCharSpan(value);
+    }
+
+    public static ReadonlyCharSpan AsSpan(this char[] value, int start, int length)
+    {
+        return new ReadonlyCharSpan(value, start, length);
+    }
+
+    public static char[] ToArray(this string value)
+    {
+        return value.ToCharArray();
+    }
+    public static ReadonlyCharSpan Slice(this ReadonlyCharSpan value, int start, int length)
+    {
+        return value.Substring(start, length);
+    }
+    public static ReadonlyCharSpan Slice(this ReadonlyCharSpan value, int start)
+    {
+        return value.Substring(start);
+    }
+
+    public static ReadonlyCharSpan Slice(this CharSpan value, int start, int length)
+    {
+        return value.ToString(start, length);
+    }
+
+    public static ReadonlyCharSpan Slice(this CharSpan value, int start)
+    {
+        return value.ToString(start, value.Length - start);
+    }
+
+    public static CharSpan AllocateCharSpan(int length)
+    {
+        var charSpan = new CharSpan(length);
+        charSpan.Append(new char[length]);
+        return charSpan;
+    }
+}
+
+#endif

--- a/source/Sylvan.Data.Excel/RunTimeCompatability.cs
+++ b/source/Sylvan.Data.Excel/RunTimeCompatability.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if !NETSTANDARD2_1_OR_GREATER
 
 using ReadonlyCharSpan = System.String;
 using CharSpan = System.Text.StringBuilder;

--- a/source/Sylvan.Data.Excel/Sylvan.Data.Excel.csproj
+++ b/source/Sylvan.Data.Excel/Sylvan.Data.Excel.csproj
@@ -2,8 +2,9 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
 		<VersionPrefix>0.1.11</VersionPrefix>
-		<VersionSuffix>b0003</VersionSuffix>
+		<VersionSuffix>b0003</VersionSuffix>		
 		<Description>A cross-platform .NET library for reading Excel data files.</Description>
 		<PackageTags>excel;xls;xlsx;xlsb;datareader</PackageTags>
 		<Nullable>enable</Nullable>
@@ -12,12 +13,8 @@
 		<DefineConstants Condition="$(TargetFramework) == 'netstandard2.1'">$(DefineConstants);SPAN_PARSE</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-		<PackageReference Include="System.Memory" Version="4.5.1" />
-	</ItemGroup>
-	
 	<ItemGroup>
-		<InternalsVisibleTo Include="Sylvan.Data.Excel.Tests"/>
+		<InternalsVisibleTo Include="Sylvan.Data.Excel.Tests" />
 	</ItemGroup>
 	
 </Project>

--- a/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data.Common;

--- a/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
@@ -7,11 +7,19 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 
+#if NETSTANDARD2_0
+using ReadonlyCharSpan = System.String;
+using CharSpan = System.Text.StringBuilder;
+#else
+using ReadonlyCharSpan = System.ReadOnlySpan<char>;
+using CharSpan = System.Span<char>;
+#endif
+
 namespace Sylvan.Data.Excel;
 
 sealed class XlsxWorkbookReader : ExcelDataReader
-{
-	readonly ZipArchive package;
+{	
+    readonly ZipArchive package;
 	Dictionary<int, ExcelFormat> formats;
 	int[] xfMap;
 	int sheetIdx = -1;
@@ -351,7 +359,7 @@ sealed class XlsxWorkbookReader : ExcelDataReader
 		public int Column;
 		public int Row;
 
-		public static CellPosition Parse(ReadOnlySpan<char> str)
+		public static CellPosition Parse(ReadonlyCharSpan str)
 		{
 			int col = -1;
 			int row = 0;
@@ -474,7 +482,7 @@ sealed class XlsxWorkbookReader : ExcelDataReader
 				this.values = values;
 			}
 
-			static bool TryParse(ReadOnlySpan<char> span, out int value)
+			static bool TryParse(ReadonlyCharSpan span, out int value)
 			{
 				int a = 0;
 				for (int i = 0; i < span.Length; i++)

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -7,7 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Xml;
 
-#if NETSTANDARD2_0
+#if !NETSTANDARD2_1_OR_GREATER 
 using ReadonlyCharSpan = System.String;
 using CharSpan = System.Text.StringBuilder;
 #else


### PR DESCRIPTION
…espect to System.Memory

Added CharSpan and ReadonlyCharSpan usings to differentiate between netstandard 2.0/2.1
Removed specific System.Memory reference from netstandard2.0 so the project can easily be used with .NET 4.8/4.7/4.6 mixed netstandard projects without getting System.Memory.dll runtime errors.
Made the unit test project test both netstandard 2.0 & 2.1 by referencing NET 6 and net48