### PR TITLE
reader.NodeType == XmlNodeType.Element ->, ReadElementContentAsString

### DIFF
--- a/source/Sylvan.Data.Excel/ExcelDataReader+FieldInfo.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataReader+FieldInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace Sylvan.Data.Excel;
 

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
@@ -578,8 +578,15 @@ sealed class XlsxWorkbookReader : ExcelDataReader
 						fi.type = ExcelDataType.String;
 						break;
 					case CellType.String:
-						fi.strValue = reader.ReadContentAsString();
-						fi.type = ExcelDataType.String;
+                        if (reader.NodeType == XmlNodeType.Element)
+                        {
+                            fi.strValue = reader.ReadElementContentAsString();
+                        }
+                        else
+                        {
+                            fi.strValue = reader.ReadContentAsString();
+                        }                
+                        fi.type = ExcelDataType.String;
 						break;
 					case CellType.InlineString:
 						fi.strValue = ReadString(reader);


### PR DESCRIPTION
If a the node type is element need to use ReadElementContentAsString. 

Supporting excel file supplied by email