### PR TITLE
Added this.curFieldCount = -1 to OpenWorksheetAsync of XlsbWorkbookRe…

### DIFF
--- a/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -166,6 +166,7 @@ sealed class XlsbWorkbookReader : ExcelDataReader
 		this.reader = new RecordReader(this.sheetStream);
 		var rr = this.reader;
 		this.rowFieldCount = 0;
+		this.curFieldCount = -1;
 		this.sheetIdx = sheetIdx;
 		return Task.FromResult(InitializeSheet());
 	}


### PR DESCRIPTION
Added this.curFieldCount = -1 to OpenWorksheetAsync of XlsbWorkbookReader to fix issue with not properly parsing columns of good worksheet, after having read a bad worksheet

Fixes issue in MarkPflug/Sylvan.Data.Excel#109