### PR TITLE
Added configurable auto filter

### DIFF
--- a/source/Sylvan.Data.Excel/ExcelDataWriter.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataWriter.cs
@@ -25,6 +25,7 @@ public abstract class ExcelDataWriter :
 	bool ownsStream;
 	readonly Stream stream;
 	private protected readonly bool truncateStrings;
+	private protected readonly bool autoFilterOnHeader;
 
 
 #if ASYNC
@@ -164,6 +165,7 @@ public abstract class ExcelDataWriter :
 		this.ownsStream = options.OwnsStream;
 		this.stream = stream;
 		this.truncateStrings = options.TruncateStrings;
+		this.autoFilterOnHeader = options.AutoFilterOnHeader;
 	}
 
 	/// <summary>

--- a/source/Sylvan.Data.Excel/ExcelDataWriterOptions.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataWriterOptions.cs
@@ -22,6 +22,7 @@ public sealed class ExcelDataWriterOptions
 		this.TruncateStrings = false;
 		this.CompressionLevel = CompressionLevel.Fastest;
 		this.OwnsStream = false;
+		this.AutoFilterOnHeader = true;
 	}
 
 	/// <summary>
@@ -39,4 +40,11 @@ public sealed class ExcelDataWriterOptions
 	/// The compression level to use.
 	/// </summary>
 	public CompressionLevel CompressionLevel { get; set; }
+	
+	/// <summary>
+	/// Indicates whether to automatically add an auto filter property to the header row.
+	/// This can break compatibility with libraries for processing Excel files.
+	/// </summary>
+	/// <remarks>True by default.</remarks>
+	public bool AutoFilterOnHeader { get; set; }
 }

--- a/source/Sylvan.Data.Excel/Xlsb/XlsbDataWriter.cs
+++ b/source/Sylvan.Data.Excel/Xlsb/XlsbDataWriter.cs
@@ -538,15 +538,17 @@ sealed partial class XlsbDataWriter : ExcelDataWriter
 		}
 		bw.WriteMarker(RecordType.DataEnd);
 
-		// apply filtering to the header row.
-		bw.WriteType(RecordType.FilterStart);
-		bw.Write7BitEncodedInt(16);
-		bw.Write(0);
-		bw.Write(0);
-		bw.Write(0);
-		bw.Write(fieldCount);
-		bw.WriteMarker(RecordType.FilterEnd);
-
+		if (this.autoFilterOnHeader)
+		{
+			// apply filtering to the header row.
+			bw.WriteType(RecordType.FilterStart);
+			bw.Write7BitEncodedInt(16);
+			bw.Write(0);
+			bw.Write(0);
+			bw.Write(0);
+			bw.Write(fieldCount);
+			bw.WriteMarker(RecordType.FilterEnd);	
+		}
 
 		bw.WriteWorksheetEnd();
 		return new WriteResult(row, complete);

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxDataWriter.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxDataWriter.cs
@@ -228,8 +228,13 @@ sealed partial class XlsxDataWriter : ExcelDataWriter
 		xw.Write("</sheetData>");
 
 		var end = ExcelSchema.GetExcelColumnName(fieldWriters.Length - 1);
-		// apply filter to header row
-		xw.Write($"<autoFilter ref=\"A1:{end}{row}\"/>");
+		
+		if (this.autoFilterOnHeader)
+		{
+			// apply filter to header row
+			xw.Write($"<autoFilter ref=\"A1:{end}{row}\"/>");	
+		}
+		
 		xw.Write("</worksheet>");
 		return new WriteResult(row, complete);
 	}


### PR DESCRIPTION
WHY: 
This is for cases where conversion is done for the purpose of further parsing the XLSX file. In our case, we are provided with XLSB and our processor can only take XLSX, but for some reason autofilter property added automatically by this library was breaking EPPlus (another Excel parsing library) ability to read the file after conversion. 

WHAT:
This PR leaves the original functionality as it was by default, but adds the ability to set whether the user want's autofilter on the first row through ExcelDataWriterOptions.