### PR TITLE
Add option to control whether or not the reader will skip empty rows

### DIFF
--- a/source/Sylvan.Data.Excel/ExcelDataReader.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataReader.cs
@@ -45,7 +45,7 @@ public abstract partial class ExcelDataReader : DbDataReader, IDisposable, IDbCo
 
 	private protected bool readHiddenSheets;
 	private protected bool errorAsNull;
-	private protected bool ignoreEmptyTrailingRows;
+	private protected bool ignoreEmptyRows;
 
 	private protected int rowCount;
 	private protected int rowFieldCount;
@@ -88,7 +88,7 @@ public abstract partial class ExcelDataReader : DbDataReader, IDisposable, IDbCo
 		this.schema = options.Schema;
 		this.errorAsNull = options.GetErrorAsNull;
 		this.readHiddenSheets = options.ReadHiddenWorksheets;
-		this.ignoreEmptyTrailingRows = options.IgnoreEmptyTrailingRows;
+		this.ignoreEmptyRows = options.IgnoreEmptyRows;
 		this.state = State.Initializing;
 		this.values = Array.Empty<FieldInfo>();
 		this.sst = Array.Empty<string>();

--- a/source/Sylvan.Data.Excel/ExcelDataReader.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataReader.cs
@@ -45,6 +45,7 @@ public abstract partial class ExcelDataReader : DbDataReader, IDisposable, IDbCo
 
 	private protected bool readHiddenSheets;
 	private protected bool errorAsNull;
+	private protected bool ignoreEmptyTrailingRows;
 
 	private protected int rowCount;
 	private protected int rowFieldCount;
@@ -87,6 +88,7 @@ public abstract partial class ExcelDataReader : DbDataReader, IDisposable, IDbCo
 		this.schema = options.Schema;
 		this.errorAsNull = options.GetErrorAsNull;
 		this.readHiddenSheets = options.ReadHiddenWorksheets;
+		this.ignoreEmptyTrailingRows = options.IgnoreEmptyTrailingRows;
 		this.state = State.Initializing;
 		this.values = Array.Empty<FieldInfo>();
 		this.sst = Array.Empty<string>();

--- a/source/Sylvan.Data.Excel/ExcelDataReaderOptions.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataReaderOptions.cs
@@ -64,4 +64,9 @@ public sealed class ExcelDataReaderOptions
 	/// Indicates that the data stream should be disposed when the reader is disposed.
 	/// </summary>
 	public bool OwnsStream { get; set; }
+
+	/// <summary>
+	/// Indicates that the reader will stop reading at the first row with all blanks
+	/// </summary>
+	public bool IgnoreEmptyTrailingRows { get; set; }
 }

--- a/source/Sylvan.Data.Excel/ExcelDataReaderOptions.cs
+++ b/source/Sylvan.Data.Excel/ExcelDataReaderOptions.cs
@@ -66,7 +66,8 @@ public sealed class ExcelDataReaderOptions
 	public bool OwnsStream { get; set; }
 
 	/// <summary>
-	/// Indicates that the reader will stop reading at the first row with all blanks
+	/// Indicates that the reader will skip empty rows and continue reading until another
+	/// non-empty row is found or the sheet ends.
 	/// </summary>
-	public bool IgnoreEmptyTrailingRows { get; set; }
+	public bool IgnoreEmptyRows { get; set; } = true;
 }

--- a/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -293,7 +293,7 @@ sealed class XlsbWorkbookReader : ExcelDataReader
 				}
 				if (c == 0)
 				{
-					if (this.ignoreEmptyTrailingRows)
+					if (this.ignoreEmptyRows)
 					{
 						continue;
 					}

--- a/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsb/XlsbWorkbookReader.cs
@@ -293,7 +293,12 @@ sealed class XlsbWorkbookReader : ExcelDataReader
 				}
 				if (c == 0)
 				{
-					continue;
+					if (this.ignoreEmptyTrailingRows)
+					{
+						continue;
+					}
+
+					this.rowFieldCount = 0;
 				}
 				if (rowIndex < parsedRowIndex)
 				{

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
@@ -405,8 +405,13 @@ sealed class XlsxWorkbookReader : ExcelDataReader
 				var c = ParseRowValues();
 				if (c == 0)
 				{
-					// handles trailing empty rows.
-					continue;
+					if (this.ignoreEmptyTrailingRows)
+					{
+						// handles trailing empty rows.
+						continue;
+					}
+
+					this.rowFieldCount = 0;
 				}
 				if (rowIndex < parsedRowIndex)
 				{

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxWorkbookReader.cs
@@ -405,7 +405,7 @@ sealed class XlsxWorkbookReader : ExcelDataReader
 				var c = ParseRowValues();
 				if (c == 0)
 				{
-					if (this.ignoreEmptyTrailingRows)
+					if (this.ignoreEmptyRows)
 					{
 						// handles trailing empty rows.
 						continue;


### PR DESCRIPTION
This PR addresses #164 

Add the `IgnoreEmptyRows` option to the `ExcelDataReaderOptions` class. Default behaviour is to skip over any empty rows in the spreadsheet until another non-empty row is found or the spreadsheet ends. In some edge cases a spreadsheet may contain a large number of empty rows which can cause calls to the `Read()` method to take a long time since it is reading over and skipping many rows. Setting this option to false disables will result in the reader returning every row regardless of how many fields the row contains, which means library users may control if the reader continues to read when a row is empty.