### PR TITLE
Ignore number stored as text errors

### DIFF
--- a/source/Sylvan.Data.Excel.Tests/ExcelDataWriterTests.cs
+++ b/source/Sylvan.Data.Excel.Tests/ExcelDataWriterTests.cs
@@ -205,6 +205,7 @@ public abstract class ExcelDataWriterTests
 					Id = i, //int32
 					Name = "Name" + i, //string
 					ValueInt = r.Next(), // another, bigger int
+					ValueStr = r.Next().ToString(), // integer as string
 					ValueDouble = r.NextDouble() * 100d, // double
 					Amount = (decimal)r.NextDouble(), // decimal
 					DateTime = new DateTime(2020, 1, 1).AddHours(i), // datetime

--- a/source/Sylvan.Data.Excel/Xlsx/XlsxDataWriter.cs
+++ b/source/Sylvan.Data.Excel/Xlsx/XlsxDataWriter.cs
@@ -228,8 +228,12 @@ sealed partial class XlsxDataWriter : ExcelDataWriter
 		xw.Write("</sheetData>");
 
 		var end = ExcelSchema.GetExcelColumnName(fieldWriters.Length - 1);
+		var allCellsRef = $"A1:{end}{row}";
 		// apply filter to header row
-		xw.Write($"<autoFilter ref=\"A1:{end}{row}\"/>");
+		xw.Write($"<autoFilter ref=\"{allCellsRef}\"/>");
+		xw.Write("<ignoredErrors>");
+		xw.Write($"<ignoredError sqref=\"{allCellsRef}\" numberStoredAsText=\"1\"/>");
+		xw.Write("</ignoredErrors>");
 		xw.Write("</worksheet>");
 		return new WriteResult(row, complete);
 	}


### PR DESCRIPTION
Before this pull request, when a number is stored as text, Excel displays errors (with a green triangle in the top left corner of the cell).
<img width="587" alt="Screenshot 2024-05-17 at 22 37 08" src="https://github.com/MarkPflug/Sylvan.Data.Excel/assets/51363/a96b3542-c7c0-44b0-8429-32d2e38bd2f0">

After this pull request, the errors are gone.
<img width="588" alt="Screenshot 2024-05-17 at 22 37 41" src="https://github.com/MarkPflug/Sylvan.Data.Excel/assets/51363/2eb0e3fc-5a86-43d5-afb3-7c0cf3a112ab">