### PR TITLE
Update Ole2Package+Ole2Stream.cs to fix read overflow

### DIFF
--- a/source/Sylvan.Data.Excel/Packaging/Ole2Package+Ole2Stream.cs
+++ b/source/Sylvan.Data.Excel/Packaging/Ole2Package+Ole2Stream.cs
@@ -140,6 +140,11 @@ partial class Ole2Package
 				int len = 0;
 				while (len < readLen)
 				{
+					// Handle case where we are at the end of the buffer and only have a small section left to read
+					if(offset + readLen > buffer.Length)
+					{
+						readLen = buffer.Length - offset;
+					}
 					int l = stream.Read(buffer, offset, readLen);
 					if (l == 0)
 					{


### PR DESCRIPTION
This fixes an issue that can occur where the final loop will attempt to read past the buffer because the initial reads are large but not large enough for the full buffer nor a multiple of the buffer size.  tis results in a out of bounds exception.