### PR TITLE
fix issue when ReadStringBuffer returns without populating the strBuffer

### DIFF
--- a/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader+RecordReader.cs
+++ b/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader+RecordReader.cs
@@ -183,6 +183,12 @@ sealed partial class XlsWorkbookReader
 				var recordPos = bufferPos - recordOff;
 				int recordBytes = recordLen - recordPos;
 
+				//if the start of the buffer is a null character, advance past it
+				if (i == 0 && buffer[bufferPos] == 0x0000) 
+				{
+					bufferPos += charSize;
+				}
+
 				// if the string sits entirely within the current record
 				// we can directly create a string from it.
 				if (i == 0 && recordBytes >= byteCount)

--- a/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader+RecordReader.cs
+++ b/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader+RecordReader.cs
@@ -183,12 +183,6 @@ sealed partial class XlsWorkbookReader
 				var recordPos = bufferPos - recordOff;
 				int recordBytes = recordLen - recordPos;
 
-				//if the start of the buffer is a null character, advance past it
-				if (i == 0 && buffer[bufferPos] == 0x0000) 
-				{
-					bufferPos += charSize;
-				}
-
 				// if the string sits entirely within the current record
 				// we can directly create a string from it.
 				if (i == 0 && recordBytes >= byteCount)

--- a/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader+RecordReader.cs
+++ b/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader+RecordReader.cs
@@ -244,9 +244,7 @@ sealed partial class XlsWorkbookReader
 			else
 				len = ReadInt16();
 
-			ReadStringBuffer(len, true);
-			var str = new string(strBuffer, 0, len);
-			return str;
+			return ReadStringBuffer(len, true);
 		}
 
 		public string ReadString8()


### PR DESCRIPTION
ReadStringBuffer can return early "if the string sits entirely within the current record" without populating the strBuffer.
ReadStringBuffer returns the string needed anyway so we can just return ReadStringBuffer.

