### PR TITLE
Minor cleanups

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
   
    <Target

--- a/source/Sylvan.Data.Excel.Tests/Sylvan.Data.Excel.Tests.csproj
+++ b/source/Sylvan.Data.Excel.Tests/Sylvan.Data.Excel.Tests.csproj
@@ -3,14 +3,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net48</TargetFrameworks>
 		<RootNamespace>Sylvan.Data.Excel</RootNamespace>
-		<IsPackable>false</IsPackable>
-		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-		
-		<!-- 
-		Suppress nuget vulnerability warnings, as I'm not really concerned about these in the test project.
-		Maybe I should be?
-		-->
-		<NoWarn>$(NoWarn);NU1903;xUnit2004</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
@@ -18,20 +10,16 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Sylvan.BuildTools.Resources" Version="0.6.2">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		<PackageReference Include="Sylvan.BuildTools.Resources" Version="0.6.2" PrivateAssets="all" />
 		<PackageReference Include="Sylvan.Data" Version="0.2.16" />
-		<PackageReference Include="Sylvan.Data.Csv" Version="1.3.9" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+		<PackageReference Include="Sylvan.Data.Csv" Version="1.4.2" />
 		<ProjectReference Include="..\Sylvan.Data.Excel\Sylvan.Data.Excel.csproj" />
 		<Reference Include="System.IO.Compression" Condition="$(TargetFramework) == 'net48'" />
 	</ItemGroup>
 
 	
 	<ItemGroup>
-		<StaticResourceFolder Include="TestData" />
+		<StaticResourceFolder Include="TestData" Visible="false" />
 		<None Update="Data/**/*">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader.cs
+++ b/source/Sylvan.Data.Excel/Xls/XlsWorkbookReader.cs
@@ -199,7 +199,6 @@ sealed partial class XlsWorkbookReader : ExcelDataReader
 					default:
 						throw new NotSupportedException();
 				}
-				throw new InvalidDataException();//"Expected sheetBOF"
 			}
 		}
 		throw new InvalidDataException();//"Expected sheetBOF"


### PR DESCRIPTION
* Update test dependencies
* Remove `System.Data.SqlClient` which is not used for anything
* Also remove all warnings removal (NoWarn property) since there are no warnings anyway. I guess `System.Data.SqlClient` was the offender for vulnerability warnings (NU1903)
* Delete unreachable code