### PR TITLE
Improve the exception when GetFieldValue<> is used on an unsupported type

### DIFF
--- a/source/Sylvan.Data.Excel/FieldAccessor.cs
+++ b/source/Sylvan.Data.Excel/FieldAccessor.cs
@@ -19,7 +19,7 @@ static class Accessor<T>
 			{
 				return EnumAccessor<T>.Instance;
 			}
-			throw new NotSupportedException(); // TODO: exception type?
+			throw new NotSupportedException($"GetFieldValue<{typeof(T).Name}>() is not supported by {nameof(ExcelDataReader)}.");
 		}
 		return acc;
 	}


### PR DESCRIPTION
Using NotSupportedException is fine IMHO but a custom error message is much better than the default _Specified method is not supported_ error.

For example:
> System.NotSupportedException : GetFieldValue\<DateOnly\>() is not supported by ExcelDataReader.